### PR TITLE
handle missing connection predicates gracefully

### DIFF
--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -11,6 +11,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from Products.PleiadesEntity.time import to_ad
 import logging
+import traceback
 
 
 log = logging.getLogger('Products.PleiadesEntity')
@@ -347,6 +348,7 @@ class ConnectionsTable(ChildrenTable):
         log.info(
             '"referenced" method retrieving connected place for {}'
             ''.format(ob.absolute_url()))
+        traceback.print_stack(limit=7)
         c = ob.getConnection()
         if c is None:
             raise RuntimeError('connected place was None')

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -334,7 +334,9 @@ class ConnectionsTable(ChildrenTable):
     """
 
     def accessor(self):
-        return self.context.getSubConnections()
+        connections = self.context.getSubConnections()
+        log.info('IN ACCESSOR: len(connections) = {}'.format(len(connections)))
+        return connections
 
     def snippet(self, ob):
         return unicode(self.referenced(ob).Title(), "utf-8")

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -346,9 +346,8 @@ class ConnectionsTable(ChildrenTable):
     @view.memoize
     def referenced(self, ob):
         log.info(
-            '"referenced" method retrieving connected place for {}'
+            'IN REFERENCED: retrieving connected place for {}'
             ''.format(ob.absolute_url()))
-        traceback.print_stack(limit=7)
         c = ob.getConnection()
         if c is None:
             raise RuntimeError('connected place was None')
@@ -447,7 +446,9 @@ class ConnectionsTable(ChildrenTable):
         output = []
         portal_state = self.context.restrictedTraverse("@@plone_portal_state")
         anonymous = portal_state.anonymous()
+        log.info('IN ROWS: len(connections): {}'.format(len(connections)))
         for score, ob, nrefs in sorted(connections, key=lambda k: k[1].Title() or ''):
+            log.info('IN ROWS: iterating on {}'.format(ob.absolute_url()))
             if anonymous:
                 review_state = self.wftool.getInfoFor(ob, 'review_state')
                 if review_state != 'published':

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -413,18 +413,34 @@ class ConnectionsTable(ChildrenTable):
 
     def predicate_phrase(self, ob):
         predicate = self.predicate(ob)
-        title = predicate.Title()
-        label = unicode(title, 'utf-8')
-        review_state = self.wftool.getInfoFor(predicate, 'review_state')
-        attributes = {
-            'class': u'connection-predicate state-{}'.format(review_state),
-            'title': u'predicate of this connection: {}'.format(label)
-        }
-        if self.context.getId() != predicate.getId():
-            tag = u'a'
-            attributes['href'] = predicate.absolute_url()
-        else:
+        try:
+            title = predicate.Title()
+        except AttributeError:
+            if predicate is None:
+                log.info(
+                    'Connection has no target place resource: {}'
+                    ''.format(ob.absolute_url()))
+            else:
+                log.info(
+                    'Unexpected lack of title for connection: {}'
+                    ''.format(ob.absolute_url()))
+            label = '(???)'
+            attributes = {
+                'class': u'connection-predicate'
+            }
             tag = u'span'
+        else:
+            label = unicode(title, 'utf-8')
+            review_state = self.wftool.getInfoFor(predicate, 'review_state')
+            attributes = {
+                'class': u'connection-predicate state-{}'.format(review_state),
+                'title': u'predicate of this connection: {}'.format(label)
+            }
+            if self.context.getId() != predicate.getId():
+                tag = u'a'
+                attributes['href'] = predicate.absolute_url()
+            else:
+                tag = u'span'
         return self.taggify(tag, attributes, label)
 
     def taggify(self, tag, attributes, label):

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -11,7 +11,6 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from Products.PleiadesEntity.time import to_ad
 import logging
-import traceback
 
 
 log = logging.getLogger('Products.PleiadesEntity')
@@ -457,14 +456,7 @@ class ConnectionsTable(ChildrenTable):
         output = []
         portal_state = self.context.restrictedTraverse("@@plone_portal_state")
         anonymous = portal_state.anonymous()
-        log.info('IN ROWS: len(connections): {}'.format(len(connections)))
-        log.info(
-            'IN ROWS: connections are: {}'
-            ''.format(
-                '\n\t'.join([c[1].absolute_url() for c in connections]))
-            )
         for score, ob, nrefs in sorted(connections, key=lambda k: k[1].Title() or ''):
-            log.info('IN ROWS: iterating on {}'.format(ob.absolute_url()))
             if anonymous:
                 review_state = self.wftool.getInfoFor(ob, 'review_state')
                 if review_state != 'published':

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -334,9 +334,7 @@ class ConnectionsTable(ChildrenTable):
     """
 
     def accessor(self):
-        connections = self.context.getSubConnections()
-        log.info('IN ACCESSOR: len(connections) = {}'.format(len(connections)))
-        return connections
+        return self.context.getSubConnections()
 
     def snippet(self, ob):
         return unicode(self.referenced(ob).Title(), "utf-8")
@@ -347,13 +345,7 @@ class ConnectionsTable(ChildrenTable):
 
     @view.memoize
     def referenced(self, ob):
-        log.info(
-            'IN REFERENCED: retrieving connected place for {}'
-            ''.format(ob.absolute_url()))
-        c = ob.getConnection()
-        if c is None:
-            raise RuntimeError('connected place was None')
-        return c
+        return ob.getConnection()
 
     def prefix(self, ob):
         acert = AssociationCertaintyWrapper(ob).snippet
@@ -421,7 +413,8 @@ class ConnectionsTable(ChildrenTable):
 
     def predicate_phrase(self, ob):
         predicate = self.predicate(ob)
-        label = unicode(predicate.Title(), 'utf-8')
+        title = predicate.Title()
+        label = unicode(title, 'utf-8')
         review_state = self.wftool.getInfoFor(predicate, 'review_state')
         attributes = {
             'class': u'connection-predicate state-{}'.format(review_state),

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -446,6 +446,7 @@ class ConnectionsTable(ChildrenTable):
         portal_state = self.context.restrictedTraverse("@@plone_portal_state")
         for score, ob, nrefs in sorted(connections, key=lambda k: k[1].Title() or ''):
             if portal_state.anonymous():
+                log.info('portal state is anonymous')
                 review_state = self.wftool.getInfoFor(ob, 'review_state')
                 if review_state != 'published':
                     continue

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -447,6 +447,7 @@ class ConnectionsTable(ChildrenTable):
         portal_state = self.context.restrictedTraverse("@@plone_portal_state")
         anonymous = portal_state.anonymous()
         log.info('IN ROWS: len(connections): {}'.format(len(connections)))
+        log.info('IN ROWS: number of unique connections: {}'.format(len(list(set(connections)))))
         for score, ob, nrefs in sorted(connections, key=lambda k: k[1].Title() or ''):
             log.info('IN ROWS: iterating on {}'.format(ob.absolute_url()))
             if anonymous:

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -448,8 +448,10 @@ class ConnectionsTable(ChildrenTable):
         anonymous = portal_state.anonymous()
         log.info('IN ROWS: len(connections): {}'.format(len(connections)))
         log.info(
-            'IN ROWS: connections are:'
-            '\n\t'.join([c[1].absolute_url() for c in connections]))
+            'IN ROWS: connections are: {}'
+            ''.format(
+                '\n\t'.join([c[1].absolute_url() for c in connections]))
+            )
         for score, ob, nrefs in sorted(connections, key=lambda k: k[1].Title() or ''):
             log.info('IN ROWS: iterating on {}'.format(ob.absolute_url()))
             if anonymous:

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -444,9 +444,9 @@ class ConnectionsTable(ChildrenTable):
     def rows(self, connections):
         output = []
         portal_state = self.context.restrictedTraverse("@@plone_portal_state")
+        anonymous = portal_state.anonymous()
         for score, ob, nrefs in sorted(connections, key=lambda k: k[1].Title() or ''):
-            if portal_state.anonymous():
-                log.info('portal state is anonymous')
+            if anonymous:
                 review_state = self.wftool.getInfoFor(ob, 'review_state')
                 if review_state != 'published':
                     continue

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -349,7 +349,7 @@ class ConnectionsTable(ChildrenTable):
             ''.format(ob.absolute_url()))
         c = ob.getConnection()
         if c is None:
-            log.info('connected place was None')
+            raise RuntimeError('connected place was None')
         return c
 
     def prefix(self, ob):

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -347,7 +347,10 @@ class ConnectionsTable(ChildrenTable):
         log.info(
             '"referenced" method retrieving connected place for {}'
             ''.format(ob.absolute_url()))
-        return ob.getConnection()
+        c = ob.getConnection()
+        if c is None:
+            log.info('connected place was None')
+        return c
 
     def prefix(self, ob):
         acert = AssociationCertaintyWrapper(ob).snippet

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -447,7 +447,9 @@ class ConnectionsTable(ChildrenTable):
         portal_state = self.context.restrictedTraverse("@@plone_portal_state")
         anonymous = portal_state.anonymous()
         log.info('IN ROWS: len(connections): {}'.format(len(connections)))
-        log.info('IN ROWS: number of unique connections: {}'.format(len(list(set(connections)))))
+        log.info(
+            'IN ROWS: connections are:'
+            '\n\t'.join([c[1].absolute_url() for c in connections]))
         for score, ob, nrefs in sorted(connections, key=lambda k: k[1].Title() or ''):
             log.info('IN ROWS: iterating on {}'.format(ob.absolute_url()))
             if anonymous:

--- a/Products/PleiadesEntity/browser/attestations.py
+++ b/Products/PleiadesEntity/browser/attestations.py
@@ -344,6 +344,9 @@ class ConnectionsTable(ChildrenTable):
 
     @view.memoize
     def referenced(self, ob):
+        log.info(
+            '"referenced" method retrieving connected place for {}'
+            ''.format(ob.absolute_url()))
         return ob.getConnection()
 
     def prefix(self, ob):


### PR DESCRIPTION
Instead of throwing a traceback while trying unsuccessfully to get a title or other information from a connected place resource, produce a placeholder and go ahead and render the entire view. This probably only happens in the case of redirected or broken connections, but it's still worth protecting the parent place view for users. Addresses https://github.com/isawnyu/pleiades-gazetteer/issues/331