### PR TITLE
Add URI to various vocabulary JSON fields

### DIFF
--- a/Products/PleiadesEntity/browser/adapters/location.py
+++ b/Products/PleiadesEntity/browser/adapters/location.py
@@ -2,15 +2,17 @@ from Products.PleiadesEntity.time import to_ad
 from . import ContentExportAdapter
 from . import PlaceSubObjectExportAdapter
 from . import TemporalExportAdapter
+from . import CertaintyExportAdapter
 from . import WorkExportAdapter
 from . import archetypes_getter
+from . import vocabulary_uri
 from . import memoize_all_methods
 
 
 @memoize_all_methods
 class LocationExportAdapter(
         WorkExportAdapter, TemporalExportAdapter, ContentExportAdapter,
-        PlaceSubObjectExportAdapter):
+        CertaintyExportAdapter, PlaceSubObjectExportAdapter):
 
     def geometry(self):
         return self.extent()
@@ -28,10 +30,11 @@ class LocationExportAdapter(
         return s
 
     featureType = archetypes_getter('featureType')
-    associationCertainty = archetypes_getter('associationCertainty')
+    featureTypeURI = vocabulary_uri('place-types', 'featureType')
     details = archetypes_getter('text')
     archaeologicalRemains = archetypes_getter('archaeologicalRemains')
     locationType = archetypes_getter('locationType')
+    locationTypeURI = vocabulary_uri('location-types', 'locationType')
 
     _accuracy = archetypes_getter('accuracy', raw=False)
     def accuracy(self):

--- a/Products/PleiadesEntity/browser/adapters/name.py
+++ b/Products/PleiadesEntity/browser/adapters/name.py
@@ -2,6 +2,7 @@ from . import ContentExportAdapter
 from . import PlaceSubObjectExportAdapter
 from . import TemporalExportAdapter
 from . import WorkExportAdapter
+from . import CertaintyExportAdapter
 from . import archetypes_getter
 from . import export_config
 from . import memoize_all_methods
@@ -10,7 +11,7 @@ from . import memoize_all_methods
 @memoize_all_methods
 class NameExportAdapter(
         WorkExportAdapter, TemporalExportAdapter, ContentExportAdapter,
-        PlaceSubObjectExportAdapter):
+        CertaintyExportAdapter, PlaceSubObjectExportAdapter):
 
     attested = archetypes_getter('nameAttested')
     language = archetypes_getter('nameLanguage')
@@ -18,7 +19,6 @@ class NameExportAdapter(
     nameType = archetypes_getter('nameType')
     transcriptionAccuracy = archetypes_getter('accuracy')
     transcriptionCompleteness = archetypes_getter('completeness')
-    associationCertainty = archetypes_getter('associationCertainty')
     details = archetypes_getter('text')
 
 

--- a/Products/PleiadesEntity/browser/adapters/place.py
+++ b/Products/PleiadesEntity/browser/adapters/place.py
@@ -8,6 +8,7 @@ from . import WorkExportAdapter
 from . import get_export_adapter
 from . import export_config
 from . import memoize_all_methods
+from . import vocabulary_uri
 import geojson
 import re
 
@@ -50,6 +51,17 @@ class PlaceExportAdapter(WorkExportAdapter, ContentExportAdapter):
 
     def placeTypes(self):
         return self.brain.getFeatureType
+
+    def placeTypeURIs(self):
+        uris = []
+        for feature_type in self.brain.getFeatureType:
+            uris.append(
+                vocabulary_uri(
+                    'place-types',
+                    'value'
+                )({'value': feature_type})
+            )
+        return uris
 
     def subject(self):
         return self.brain.Subject


### PR DESCRIPTION
A number of JSON fields contain the value of a vocabulary. This change
adds a field alongside (usually fieldURI) that contains the fully-qualified
URI to the vocabulary item.

This PR fixes https://github.com/isawnyu/pleiades-gazetteer/issues/367

NB: This is currently a draft PR as due to the uncertain state of staging branches