### PR TITLE
Add new `connections` attribute to Places JSON

### DIFF
--- a/Products/PleiadesEntity/browser/adapters/configure.zcml
+++ b/Products/PleiadesEntity/browser/adapters/configure.zcml
@@ -5,6 +5,10 @@
   >
 
   <adapter
+    for="Products.PleiadesEntity.content.interfaces.IConnection"
+    factory=".connection.ConnectionExportAdapter" />
+
+  <adapter
     for="Products.CMFCore.interfaces.IContentish"
     factory=".ContentExportAdapter" />
 

--- a/Products/PleiadesEntity/browser/adapters/connection.py
+++ b/Products/PleiadesEntity/browser/adapters/connection.py
@@ -1,0 +1,32 @@
+from Products.PleiadesEntity.time import to_ad
+from . import ContentExportAdapter
+from . import PlaceSubObjectExportAdapter
+from . import TemporalExportAdapter
+from . import WorkExportAdapter
+from . import archetypes_getter
+from . import get_export_adapter
+from . import memoize_all_methods
+
+
+@memoize_all_methods
+class ConnectionExportAdapter(
+    ContentExportAdapter,
+    WorkExportAdapter,
+    TemporalExportAdapter,
+    PlaceSubObjectExportAdapter):
+
+    associationCertainty = archetypes_getter('associationCertainty')
+    details = archetypes_getter('text')
+
+    connectionType = archetypes_getter('relationshipType')
+
+    def connectionTypeURI(self):
+        return "{}/relationship-types/{}".format(
+            self.context.restrictedTraverse('vocabularies').aq_inner.absolute_url(),
+            self.context.getRelationshipType()
+        )
+
+    def connectsTo(self):
+        target = self.context.getConnection()
+        adapter = get_export_adapter(target)
+        return adapter.uri()

--- a/Products/PleiadesEntity/browser/adapters/place.py
+++ b/Products/PleiadesEntity/browser/adapters/place.py
@@ -27,6 +27,8 @@ class PlaceExportAdapter(WorkExportAdapter, ContentExportAdapter):
             for id in (self._connectsWith() + self._hasConnectionsWith())
         ]
 
+    connections = export_children('Connection')
+
     def reprPoint(self):
         value = self.brain.reprPt
         if not value:


### PR DESCRIPTION
This adds a JSON marshalling adapter for Connections and includes
the connections children in the marshalling of a place.

This fixes https://github.com/isawnyu/pleiades-gazetteer/issues/345

NB: This PR is currently a draft due to uncertainty about the state of staging branches