### PR TITLE
Add Apple maps link below map on place pages

### DIFF
--- a/Products/PleiadesEntity/skins/PleiadesEntity/place_view.pt
+++ b/Products/PleiadesEntity/skins/PleiadesEntity/place_view.pt
@@ -121,7 +121,10 @@
                   GeoNames</a>,
                 <a href=""
                   tal:attributes="href string:http://maps.google.com/?q=$mlat,$mlon">
-                  Google Maps</a>, or
+                  Google Maps</a>,
+                <a href=""
+                  tal:attributes="href string:http://maps.apple.com/?ll=$mlat,$mlon">
+                  Apple Maps</a>, or
                 <a href=""
                   tal:attributes="href string:http://openstreetmap.org/?mlat=$mlat&amp;mlon=$mlon&amp;zoom=12&amp;layers=M">
                   OpenStreetMap</a>.</span>


### PR DESCRIPTION
Related to [issue #520](https://github.com/isawnyu/pleiades-gazetteer/issues/520).

This PR will add an Apple Map link below maps on places pages .